### PR TITLE
fix pixel perfect camera and enemy sorting

### DIFF
--- a/LiveOrDie/Assets/ArtResources/Character/wolf_sprite_sheet.png.meta
+++ b/LiveOrDie/Assets/ArtResources/Character/wolf_sprite_sheet.png.meta
@@ -34,7 +34,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -72,7 +72,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -106,6 +106,19 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites:
@@ -117,11 +130,15 @@ TextureImporter:
         y: 0
         width: 640
         height: 440
-      alignment: 0
-      pivot: {x: 0, y: 0}
+      alignment: 9
+      pivot: {x: 0.5, y: 0.1}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
-      physicsShape: []
+      physicsShape:
+      - - {x: 183, y: -201}
+        - {x: 182, y: -145}
+        - {x: -222.68546, y: -144.5784}
+        - {x: -222.5, y: -202.5}
       tessellationDetail: 0
       bones: []
       spriteID: 3ebe8af0053ab364da97e3b9c046bf82
@@ -138,11 +155,15 @@ TextureImporter:
         y: 0
         width: 640
         height: 440
-      alignment: 0
-      pivot: {x: 0, y: 0}
+      alignment: 9
+      pivot: {x: 0.5, y: 0.1}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
-      physicsShape: []
+      physicsShape:
+      - - {x: 183, y: -201}
+        - {x: 182, y: -145}
+        - {x: -222.68546, y: -144.5784}
+        - {x: -222.5, y: -202.5}
       tessellationDetail: 0
       bones: []
       spriteID: 824619003f83f614a867cc1a7d3590aa
@@ -159,11 +180,15 @@ TextureImporter:
         y: 0
         width: 640
         height: 440
-      alignment: 0
-      pivot: {x: 0, y: 0}
+      alignment: 9
+      pivot: {x: 0.5, y: 0.1}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
-      physicsShape: []
+      physicsShape:
+      - - {x: 183, y: -201}
+        - {x: 182, y: -145}
+        - {x: -222.68546, y: -144.5784}
+        - {x: -222.5, y: -202.5}
       tessellationDetail: 0
       bones: []
       spriteID: b29f192fec64f6c488996a69dcd644b5
@@ -180,11 +205,15 @@ TextureImporter:
         y: 0
         width: 640
         height: 440
-      alignment: 0
-      pivot: {x: 0, y: 0}
+      alignment: 9
+      pivot: {x: 0.5, y: 0.1}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
-      physicsShape: []
+      physicsShape:
+      - - {x: 183, y: -201}
+        - {x: 182, y: -145}
+        - {x: -222.68546, y: -144.5784}
+        - {x: -222.5, y: -202.5}
       tessellationDetail: 0
       bones: []
       spriteID: 1f74e3f9cd0274c4aae0dc06caaf9040

--- a/LiveOrDie/Assets/Resources/Prefabs/Enemy.prefab
+++ b/LiveOrDie/Assets/Resources/Prefabs/Enemy.prefab
@@ -74,9 +74,9 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 1574922491
-  m_SortingLayer: 8
-  m_SortingOrder: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 2
   m_Sprite: {fileID: 329535362, guid: a0d636c7478290d4cac60dd41d8d8deb, type: 3}
   m_Color: {r: 0.8867924, g: 0.8826094, b: 0.8826094, a: 1}
   m_FlipX: 0
@@ -87,7 +87,7 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
+  m_SpriteSortPoint: 1
 --- !u!95 &-5170929297750550404
 Animator:
   serializedVersion: 5

--- a/LiveOrDie/Assets/Resources/Prefabs/Main Camera.prefab
+++ b/LiveOrDie/Assets/Resources/Prefabs/Main Camera.prefab
@@ -63,14 +63,14 @@ Camera:
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
-    y: 0
-    width: 1
-    height: 1
+    y: 0.049958367
+    width: 1.0004162
+    height: 0.8992506
   near clip plane: 0.3
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 7
+  orthographic size: 5.625
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -127,5 +127,5 @@ MonoBehaviour:
   m_UpscaleRT: 0
   m_PixelSnapping: 0
   m_CropFrameX: 0
-  m_CropFrameY: 0
+  m_CropFrameY: 1
   m_StretchFill: 0


### PR DESCRIPTION
Quick fixes to pixel perfect camera and enemy sorting. The enemies now sort in front and behind objects in the scene properly. Camera is constrained in y direction, so pixel perfect camera works properly. 
![image](https://github.com/ucsb-cs148-w24/project-pj09-liveordie/assets/86684522/b78ed188-4437-4653-9ead-773726059298)
