### PR TITLE
Bug: add assembly definitions and modify test assembly to fix build

### DIFF
--- a/LiveOrDie/Assets/Scripts/BasicFrame/BasicFrameScriptsAssembly.asmdef
+++ b/LiveOrDie/Assets/Scripts/BasicFrame/BasicFrameScriptsAssembly.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "BasicFrameScriptsAssembly",
+    "rootNamespace": "",
+    "references": [
+        "GUID:6055be8ebefd69e48b49212b09b47b2f"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/LiveOrDie/Assets/Scripts/BasicFrame/BasicFrameScriptsAssembly.asmdef.meta
+++ b/LiveOrDie/Assets/Scripts/BasicFrame/BasicFrameScriptsAssembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6e433b69e74b715459006fa167bb37c1
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/Characters/MainCharacters/Player.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/Characters/MainCharacters/Player.cs
@@ -1,4 +1,3 @@
-using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.TextCore.Text;
 public class Player : MonoBehaviour

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/LiveOrDieScriptsAssembly.asmdef
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/LiveOrDieScriptsAssembly.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "LiveOrDieScriptsAssembly",
+    "rootNamespace": "",
+    "references": [
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:6e433b69e74b715459006fa167bb37c1",
+        "GUID:21b0c8d1703a94250bfac916590cea4f"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/LiveOrDieScriptsAssembly.asmdef.meta
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/LiveOrDieScriptsAssembly.asmdef.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: f6908f041e5ee40acb1d70aade641d24
-AssemblyDefinitionReferenceImporter:
+guid: ad769053a986ed84aa750e9b5bccc2ae
+AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/LiveOrDie/Assets/Scripts/ScriptsAssembly.asmref
+++ b/LiveOrDie/Assets/Scripts/ScriptsAssembly.asmref
@@ -1,3 +1,0 @@
-{
-    "reference": "GUID:ccef606e2aef04cbe937890c832880d6"
-}

--- a/LiveOrDie/Assets/Tests/GameTestAssembly.asmdef
+++ b/LiveOrDie/Assets/Tests/GameTestAssembly.asmdef
@@ -9,10 +9,16 @@
         "GUID:e0cd26848372d4e5c891c569017e11f1",
         "GUID:2bafac87e7f4b9b418d9448d219b01ab",
         "GUID:315d634a9ac6d460a9515f5a56be6311",
-        "GUID:21b0c8d1703a94250bfac916590cea4f"
+        "GUID:21b0c8d1703a94250bfac916590cea4f",
+        "GUID:ad769053a986ed84aa750e9b5bccc2ae"
     ],
     "includePlatforms": [],
-    "excludePlatforms": [],
+    "excludePlatforms": [
+        "macOSStandalone",
+        "WebGL",
+        "WindowsStandalone32",
+        "WindowsStandalone64"
+    ],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [

--- a/LiveOrDie/Assets/Tests/MainScenePanelTests.cs
+++ b/LiveOrDie/Assets/Tests/MainScenePanelTests.cs
@@ -31,7 +31,7 @@ public class MainScenePanelTests
         var check = GameObject.Find("Enemies");
         var cloner = check.GetComponentInChildren<EnemyCloner>();
         Assert.That(cloner, Is.Not.Null);
-        Assert.That(cloner.enemySize, Is.EqualTo(10));
+        Assert.That(cloner.enemySize, Is.EqualTo(15));
         // Assert.That(cloner.wolfPrefab.name, Is.EqualTo("Wolf"));
         yield return null;
      }
@@ -114,7 +114,7 @@ public class MainScenePanelTests
         
         var script = enemy.GetComponent<EnemyCloner>();
         Assert.That(script, Is.Not.Null);
-        Assert.That(script.enemySize, Is.EqualTo(10));
+        Assert.That(script.enemySize, Is.EqualTo(15));
         yield return null;
      }
 

--- a/LiveOrDie/Assets/Tests/StartScenePanelTests.cs
+++ b/LiveOrDie/Assets/Tests/StartScenePanelTests.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;


### PR DESCRIPTION
In this PR, I modify GameTestAssembly.asmdef settings to not compile test files when building for Windows/Mac/Web. I also add some new assembly definitions to Scripts/BasicFrame and Scripts/LiveOrDie so these files will compile during build. I also remove some redundant "using" directives and update the test for enemies to check for 15 enemies spawned.

Updated GameTestAssembly.asmdef:
![image](https://github.com/ucsb-cs148-w24/project-pj09-liveordie/assets/86684522/dc5e397b-a6fc-4984-92e2-3c3e4e235153)

Tests now pass:
![image](https://github.com/ucsb-cs148-w24/project-pj09-liveordie/assets/86684522/64944620-1de4-4f36-969c-fe791672f5ad)
