### PR TITLE
Weapon Selection ⚔

### DIFF
--- a/LiveOrDie/Assets/Resources/Prefabs/Weapons/Fireball.prefab
+++ b/LiveOrDie/Assets/Resources/Prefabs/Weapons/Fireball.prefab
@@ -46,23 +46,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   weaponDamage:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0
   weaponRate:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0
   weaponLevel: 1
-  weaponName: Fireball
-  weaponDescription: A fireball that fires to the left and right
+  weaponName: 
+  weaponDescription: 
   weaponIcon: {fileID: -1367895933, guid: a841e7d2067877a4f8bc15b8e627d746, type: 3}
   autoAttackOn: 0
   cooldownTimeLeft: 0
   projectileSpeed:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0
   projectileRange:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0

--- a/LiveOrDie/Assets/Resources/Prefabs/Weapons/IncenseBurner.prefab
+++ b/LiveOrDie/Assets/Resources/Prefabs/Weapons/IncenseBurner.prefab
@@ -46,27 +46,32 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   weaponDamage:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0
   weaponRate:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0
   weaponLevel: 1
-  weaponName: Incense Burner
-  weaponDescription: Burns the enemy and heals the players with incense
+  weaponName: 
+  weaponDescription: 
   weaponIcon: {fileID: -1461128699, guid: 4fdc8d762453a5f4c98663e64df328ce, type: 3}
   autoAttackOn: 0
   cooldownTimeLeft: 0
   staticRange:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0
   staticRate:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0
   staticDuration:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0

--- a/LiveOrDie/Assets/Resources/Prefabs/Weapons/PeachWoodSword.prefab
+++ b/LiveOrDie/Assets/Resources/Prefabs/Weapons/PeachWoodSword.prefab
@@ -46,23 +46,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   weaponDamage:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0
   weaponRate:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0
   weaponLevel: 1
-  weaponName: Peach Wood Sword
-  weaponDescription: A peach wood sword to ward off the enemy
+  weaponName: 
+  weaponDescription: 
   weaponIcon: {fileID: 21300000, guid: 7f532c2a75b91ff448cf675b881c206e, type: 3}
   autoAttackOn: 0
   cooldownTimeLeft: 0
   meleeRange:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0
   meleeSwingTime:
     baseValue: 0
+    minValue: 0
     maxValue: 0
     _value: 0

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/Characters/WeaponManager.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/Characters/WeaponManager.cs
@@ -23,14 +23,14 @@ public class WeaponManager : MonoBehaviour
 
     private void Start()
     {
-        EventMgr.Instance.AddEventListener("LoadMainSceneCompleted", initWeaponChoices);
+        EventMgr.Instance.AddEventListener("LoadingPanelCompleted", initWeaponChoices);
     }
 
     private void OnDestroy()
     {
         EventMgr.Instance.RemoveEventListener<string>("AddWeapon", AddWeapon);
         EventMgr.Instance.RemoveEventListener<string>("RemoveWeapon", RemoveWeapon);
-        EventMgr.Instance.RemoveEventListener("LoadMainSceneCompleted", initWeaponChoices);
+        EventMgr.Instance.RemoveEventListener("LoadingPanelCompleted", initWeaponChoices);
     }
 
     private void initWeaponChoices()

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/Characters/WeaponManager.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/Characters/WeaponManager.cs
@@ -1,9 +1,12 @@
 using UnityEngine;
 using System.Collections.Generic;
+using TMPro;
 
 public class WeaponManager : MonoBehaviour
 {
     public Dictionary<string, Weapon> weapons;
+
+    private List<LevelUpChoice> weaponChoices;
 
     public void OnDisable(){
         weapons.Clear();
@@ -18,10 +21,44 @@ public class WeaponManager : MonoBehaviour
         
     }
 
+    private void Start()
+    {
+        EventMgr.Instance.AddEventListener("LoadMainSceneCompleted", initWeaponChoices);
+    }
+
     private void OnDestroy()
     {
         EventMgr.Instance.RemoveEventListener<string>("AddWeapon", AddWeapon);
         EventMgr.Instance.RemoveEventListener<string>("RemoveWeapon", RemoveWeapon);
+        EventMgr.Instance.RemoveEventListener("LoadMainSceneCompleted", initWeaponChoices);
+    }
+
+    private void initWeaponChoices()
+    {
+        weaponChoices = new List<LevelUpChoice>
+        {
+            new (Fireball.weaponName + " (Recommended)", 
+                Fireball.weaponDescription, 
+                () => {
+                    EventMgr.Instance.EventTrigger("AddWeapon", "Fireball");
+                }),
+            new (PeachWoodSword.weaponName,
+                PeachWoodSword.weaponDescription,
+                () => {
+                    EventMgr.Instance.EventTrigger("AddWeapon", "PeachWoodSword");
+                }),
+            new (IncenseBurner.weaponName,
+                IncenseBurner.weaponDescription,
+                () => {
+                    EventMgr.Instance.EventTrigger("AddWeapon", "IncenseBurner");
+                }),
+        };
+
+        UIMgr.Instance.ShowPanel<LevelUpPanel>("LevelUpPanel", E_PanelLayer.Top, (panel) =>
+        {
+            panel.transform.Find("Title").GetComponent<TMP_Text>().text = "Choose a weapon";
+            panel.initWithThree(weaponChoices);
+        });
     }
 
     public void AddWeapon(string name)

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/MainCameraController.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/MainCameraController.cs
@@ -9,6 +9,14 @@ public class MainCameraController : MonoBehaviour
     private Vector2 centerPoint;
     private Vector2 velocity;
 
+    void Start()
+    {
+        if(obj1 && obj2){
+            centerPoint = (obj1.position + obj2.position) / 2f;
+            transform.position = centerPoint;
+        }
+    }
+
     // Update is called once per frame
     void Update()
     {

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/UI/LoadingPanel/LoadingPanel.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/UI/LoadingPanel/LoadingPanel.cs
@@ -73,6 +73,7 @@ public class LoadingPanel : BasePanel
             yield return new WaitForSeconds(0);
         }
         UIMgr.Instance.HidePanel("LoadingPanel"); // hide itself after loading 
+        EventMgr.Instance.EventTrigger("LoadingPanelCompleted");
         
     }
     

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/UI/StartScreen/StartScreenPanel.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/UI/StartScreen/StartScreenPanel.cs
@@ -41,7 +41,7 @@ public class StartScreenPanel:BasePanel
         SceneMgr.Instance.LoadSceneAsync(sceneName, () =>
         {
             EventMgr.Instance.EventTrigger("ProgressBar", 1f);
-            // EventMgr.Instance.EventTrigger("Load"+sceneName+"Completed"); //for later usage 
+            EventMgr.Instance.EventTrigger("Load"+sceneName+"Completed"); //for later usage 
             
             
         }); 

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/UI/WeaponStatus/WeaponIconItem.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/UI/WeaponStatus/WeaponIconItem.cs
@@ -36,7 +36,7 @@ public class WeaponIconItem : MonoBehaviour, IPointerClickHandler, IPointerEnter
 
         weapon = _weapon;
 
-        weaponIconImage.sprite = weapon.weaponIcon;
+        weaponIconImage.sprite = weapon.GetWeaponIcon();
         
         EventMgr.Instance.AddEventListener<E_LevelUpChoice>("LevelUp", UpdateLevelText);
         EventMgr.Instance.AddEventListener<E_LevelUpChoice>("LevelUp", UpdateDetailsPanel);
@@ -67,7 +67,7 @@ public class WeaponIconItem : MonoBehaviour, IPointerClickHandler, IPointerEnter
 
     private void UpdateDetailsPanel(E_LevelUpChoice choice)
     {
-        WeaponDetailsTitleText.text = weapon.weaponName;
+        WeaponDetailsTitleText.text = weapon.GetWeaponName();
         WeaponDetailsBodyText.text = weapon.GetDetailString();
     }
 

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/UI/WeaponStatus/WeaponStatusPanel.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/UI/WeaponStatus/WeaponStatusPanel.cs
@@ -18,11 +18,6 @@ public class WeaponStatusPanel : BasePanel
         weaponIcons = transform.Find("WeaponIcons").gameObject;
 
         EventMgr.Instance.AddEventListener("UpdateWeaponView", RefreshWeaponView);
-
-        // for now, we just add all weapons by default
-        EventMgr.Instance.EventTrigger<string>("AddWeapon", "Fireball");
-        EventMgr.Instance.EventTrigger<string>("AddWeapon", "PeachWoodSword");
-        EventMgr.Instance.EventTrigger<string>("AddWeapon", "IncenseBurner");
     }
 
     void OnDestroy()

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/Weapon/Concrete/Fireball.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/Weapon/Concrete/Fireball.cs
@@ -6,6 +6,9 @@ public class Fireball : RangedWeapon
     private Vector3 firePointOffset = new Vector3(0,1,0);
     private SpriteRenderer p1Sprite, p2Sprite;
     private GameObject player1, player2;
+
+    public static new string weaponName = "Fireball";
+    public static new string weaponDescription = "A fireball that fires to the left and right";
     
     public override void Initialize()
     {
@@ -75,6 +78,21 @@ public class Fireball : RangedWeapon
         rateLevelModifier.value *= 0.95f;
         weaponDamage.AddModifier("LevelUp",damageLevelModifier);
         weaponRate.AddModifier("LevelUp",rateLevelModifier);
+    }
+
+    public override string GetWeaponName()
+    {
+        return weaponName;
+    }
+
+    public override string GetWeaponDescription()
+    {
+        return weaponDescription;
+    }
+
+    public override Sprite GetWeaponIcon()
+    {
+        return weaponIcon;
     }
 
     public override string GetDetailString()

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/Weapon/Concrete/IncenseBurner.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/Weapon/Concrete/IncenseBurner.cs
@@ -8,6 +8,9 @@ public class IncenseBurner : StaticWeapon
     private Transform player1Transform, player2Transform;
     private GameObject player1, player2;
 
+    public static new string weaponName = "Incense Burner";
+    public static new string weaponDescription = "Burns the enemy and heals the players with incense";
+
     public override void Initialize()
     {
         weaponDamage = new CharacterStat(baseValue: 2.0f, minValue: 0.0f, maxValue: -1.0f);
@@ -71,6 +74,21 @@ public class IncenseBurner : StaticWeapon
         staticRange.AddModifier("LevelUp", rangeLevelModifier);
         staticRate.AddModifier("LevelUp", staticRateLevelModifier);
         staticDuration.AddModifier("LevelUp", durationLevelModifier);
+    }
+
+    public override string GetWeaponName()
+    {
+        return weaponName;
+    }
+
+    public override string GetWeaponDescription()
+    {
+        return weaponDescription;
+    }
+
+    public override Sprite GetWeaponIcon()
+    {
+        return weaponIcon;
     }
 
     public override string GetDetailString()

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/Weapon/Concrete/PeachWoodSword.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/Weapon/Concrete/PeachWoodSword.cs
@@ -6,6 +6,9 @@ public class PeachWoodSword : MeleeWeapon
     private Transform player1Transform, player2Transform;
     private GameObject player1, player2;
     
+    public static new string weaponName = "Peach Wood Sword";
+    public static new string weaponDescription = "A peach wood sword that swings in a circle.";
+
     public override void Initialize() 
     {
         weaponDamage = new CharacterStat(baseValue: 1.0f, minValue: 0.0f, maxValue: -1.0f);
@@ -60,6 +63,21 @@ public class PeachWoodSword : MeleeWeapon
         weaponDamage.AddModifier("LevelUp", damageLevelModifier);
         weaponRate.AddModifier("LevelUp", rateLevelModifier);
         meleeRange.AddModifier("LevelUp", rangeLevelModifier);
+    }
+
+    public override string GetWeaponName()
+    {
+        return weaponName;
+    }
+
+    public override string GetWeaponDescription()
+    {
+        return weaponDescription;
+    }
+
+    public override Sprite GetWeaponIcon()
+    {
+        return weaponIcon;
     }
 
     public override string GetDetailString()

--- a/LiveOrDie/Assets/Scripts/LiveOrDie/Weapon/Weapon.cs
+++ b/LiveOrDie/Assets/Scripts/LiveOrDie/Weapon/Weapon.cs
@@ -8,8 +8,8 @@ public abstract class Weapon : MonoBehaviour
     public int weaponLevel;
     protected StatModifier damageLevelModifier, rateLevelModifier;
 
-    public string weaponName;
-    [TextArea] public string weaponDescription;
+    public static string weaponName = "Weapon";
+    [TextArea] public static string weaponDescription = "Weapon Description";
     public Sprite weaponIcon;
 
     public bool autoAttackOn;
@@ -44,6 +44,10 @@ public abstract class Weapon : MonoBehaviour
     }
 
     public abstract void LevelUp(E_LevelUpChoice choice);
+
+    public abstract string GetWeaponName();
+    public abstract string GetWeaponDescription();
+    public abstract Sprite GetWeaponIcon();
 
     public abstract string GetDetailString();
 


### PR DESCRIPTION
In this PR, I use the LevelUpPanel and LevelUpChoices in WeaponManager to implement weapon selection at the start of the game. I also made the name and description for weapons static for easy access.

Blocker: I tried using the EventTrigger in StartScreenPanel to keep the weapon selection from appearing until after the main scene is loaded, but it will still appear and pause the game while the LoadingPanel is fading out. I'm not sure of a good fix for this.

closes #134 

https://github.com/ucsb-cs148-w24/project-pj09-liveordie/assets/86684522/f89b1748-905f-4cbd-b580-8cdb6280837d

![image](https://github.com/ucsb-cs148-w24/project-pj09-liveordie/assets/86684522/97081309-530c-431c-a344-80a113e8bd00)
